### PR TITLE
Add OSS community health files and security tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report unexpected behavior, crashes, or incorrect matching/deletion
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. If this involves unsafe or unintended file deletion, please see [SECURITY.md](../../SECURITY.md) instead of filing a public issue.
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      placeholder: e.g. 1.0.2.42
+    validations:
+      required: true
+  - type: input
+    id: lidarr-version
+    attributes:
+      label: Lidarr version
+      placeholder: e.g. 3.1.3.4968 (nightly)
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant Lidarr log output (redact personal info/paths if needed).
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: settings
+    attributes:
+      label: Unique Singles settings
+      description: Duration tolerance, release types, title-only match action, scan interval, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/jtstothard/lidarr-plugin-uniquesingles/security/advisories/new
+    about: Please report security issues privately rather than in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Suggest an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that the plugin doesn't currently support?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Testing
+
+<!-- How did you verify this works? Include new/updated tests where practical. -->
+
+- [ ] `dotnet build UniqueSingles.sln` passes
+- [ ] `dotnet test tests/UniqueSingles.Test/UniqueSingles.Test.csproj` passes
+- [ ] `CHANGELOG.md` updated (if user-facing)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '30 4 * * 1'
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_VERSION: 8.0.405
+  LIDARR_VERSION: 3.1.3.4968
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Pin Lidarr assembly version
+        run: |
+          props=ext/Lidarr/src/Directory.Build.props
+          sed -i -E "s#<AssemblyVersion>[0-9.*]+</AssemblyVersion>#<AssemblyVersion>${LIDARR_VERSION}</AssemblyVersion>#" "$props"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - name: Build
+        run: |
+          dotnet restore UniqueSingles.sln /p:WarningsNotAsErrors="NU1902"
+          dotnet build UniqueSingles.sln -c Release /p:WarningsNotAsErrors="NU1902"
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Unique Singles will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md`
+- Issue and pull request templates
+- Dependabot config for NuGet and GitHub Actions dependencies
+- CodeQL security scanning workflow
+
 ## [1.0.2] - 2025-05-28
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior deemed inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests,
+discussions) and when an individual is officially representing the project in
+public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer via a GitHub Security Advisory (see
+[SECURITY.md](SECURITY.md)) or by opening a private communication channel
+noted in the repository. All complaints will be reviewed and investigated
+promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Thanks for considering a contribution to Unique Singles.
+
+## Getting Started
+
+This repo uses a git submodule pointing at Lidarr's source (`ext/Lidarr`), which the plugin builds against.
+
+```bash
+git clone --recurse-submodules https://github.com/jtstothard/lidarr-plugin-uniquesingles.git
+cd lidarr-plugin-uniquesingles
+# If you already cloned without --recurse-submodules:
+git submodule update --init --recursive
+```
+
+### Build
+
+```bash
+dotnet restore UniqueSingles.sln
+dotnet build UniqueSingles.sln -c Release
+```
+
+### Test
+
+```bash
+dotnet test tests/UniqueSingles.Test/UniqueSingles.Test.csproj -c Release
+```
+
+## Code Style
+
+The project uses StyleCop analyzers (see `stylecop.json`). Match the existing formatting and conventions in the file you're editing.
+
+## Making Changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your change, with tests where practical — the matching-tier logic in particular relies on test coverage to stay safe (this plugin deletes files, so regressions are high-stakes).
+3. Make sure `dotnet build` and `dotnet test` pass locally.
+4. Open a pull request against `main`. CI must pass before merge.
+5. Update `CHANGELOG.md` under an `[Unreleased]` heading if your change is user-facing.
+
+## Reporting Bugs
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml) when filing an issue. Include your Lidarr version, plugin version, and relevant logs — matching/deletion bugs are much easier to diagnose with a log excerpt.
+
+For security-sensitive issues (e.g. unsafe deletion behavior), see [SECURITY.md](SECURITY.md) instead of opening a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of Unique Singles is supported with security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately via [GitHub Security Advisories](https://github.com/jtstothard/lidarr-plugin-uniquesingles/security/advisories/new).
+
+Include as much detail as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, including a minimal Lidarr/plugin configuration if relevant
+- Any logs or stack traces that help demonstrate the issue
+
+Since Unique Singles can unmonitor and delete files, please treat any issue that could cause **unintended data loss, unauthorized file deletion, or unsafe matching behavior** as a security concern, not just a bug.
+
+We aim to acknowledge reports within a few days and will keep you updated as a fix is developed.


### PR DESCRIPTION
## Summary

Rounds out the repo's compliance with GitHub's public-repo community standards checklist:

- `SECURITY.md` — private vulnerability reporting via GitHub Security Advisories (this plugin deletes files, so this matters more than usual)
- `CONTRIBUTING.md` — build/test setup (including submodule init), code style pointer, PR process
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `.github/ISSUE_TEMPLATE/` — structured bug report and feature request forms, plus a config pointing security reports away from public issues
- `.github/PULL_REQUEST_TEMPLATE.md` — build/test checklist for contributors
- `.github/dependabot.yml` — weekly update checks for NuGet packages and GitHub Actions
- `.github/workflows/codeql.yml` — CodeQL static analysis on push/PR to main and weekly

Once merged, I'll also apply (via repo settings, not part of this diff):
- Branch protection on `main`: require this workflow's `build` status check and a PR before merging (no direct pushes, no required review count since you're the sole maintainer)
- Repo topics for discoverability
- Enable "delete branch on merge"

## Test plan

- [x] New files only — no code changes, so `dotnet build`/`dotnet test` are unaffected
- [ ] Confirm the CodeQL workflow runs successfully on this PR (first run establishes the baseline)