### PR TITLE
Add FUNDING.yml for Ko-fi sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: trshpotato


### PR DESCRIPTION
## Summary

Adds \`.github/FUNDING.yml\` pointing at the Ko-fi link already in the README, so GitHub shows a native "Sponsor" button on the repo.

## Test plan

- [x] No code changes — CI unaffected