### PR TITLE
fix: pin Lidarr assembly version to 3.1.3.4968 (fixes #1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ env:
   PLUGIN_NAME: Lidarr.Plugin.UniqueSingles
   PLUGIN_VERSION: 1.0.2.${{ github.run_number }}
   DOTNET_VERSION: 8.0.405
+  LIDARR_VERSION: 3.1.3.4968
 
 jobs:
   build:
@@ -33,6 +34,12 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Pin Lidarr assembly version
+        run: |
+          props=ext/Lidarr/src/Directory.Build.props
+          sed -i -E "s#<AssemblyVersion>[0-9.*]+</AssemblyVersion>#<AssemblyVersion>${LIDARR_VERSION}</AssemblyVersion>#" "$props"
+          grep "<AssemblyVersion>${LIDARR_VERSION}</AssemblyVersion>" "$props"
 
       - name: Build
         run: |

--- a/tests/UniqueSingles.Test/AssemblySmokeTests.cs
+++ b/tests/UniqueSingles.Test/AssemblySmokeTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Plugins;
 using Xunit;
@@ -11,10 +10,12 @@ namespace UniqueSingles.Test;
 /// </summary>
 public class AssemblySmokeTests
 {
+    private static readonly Version SupportedLidarrVersion = new(3, 1, 3, 4968);
+
     [Fact]
     public void Assembly_ContainsCommandSubclass()
     {
-        var assembly = typeof(UniqueSingles.Commands.UniqueSinglesScanCommand).Assembly;
+        var assembly = typeof(UniqueSinglesScanCommand).Assembly;
 
         var commandTypes = assembly.GetTypes()
             .Where(t => t.IsClass && !t.IsAbstract && typeof(Command).IsAssignableFrom(t))
@@ -27,7 +28,7 @@ public class AssemblySmokeTests
     [Fact]
     public void Assembly_ContainsExecuteInterfaceImplementation()
     {
-        var assembly = typeof(UniqueSingles.Commands.UniqueSinglesScanCommand).Assembly;
+        var assembly = typeof(UniqueSinglesScanCommand).Assembly;
 
         var commandType = assembly.GetTypes()
             .FirstOrDefault(t => t.Name == "UniqueSinglesScanCommand");
@@ -44,13 +45,13 @@ public class AssemblySmokeTests
             .ToList();
 
         Assert.NotEmpty(executorTypes);
-        Assert.Contains(executorTypes, t => t.Name.Contains("UniqueSinglesScanCommandService", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(executorTypes, t => t.Name.Contains("UniqueSinglesScanTask", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
     public void Assembly_ExportsConcretePluginRootWithExpectedMetadata()
     {
-        var assembly = typeof(UniqueSingles.Commands.UniqueSinglesScanCommand).Assembly;
+        var assembly = typeof(UniqueSinglesScanCommand).Assembly;
 
         var pluginRoots = assembly.GetExportedTypes()
             .Where(t => t.IsClass && !t.IsAbstract && typeof(IPlugin).IsAssignableFrom(t))
@@ -64,5 +65,18 @@ public class AssemblySmokeTests
         Assert.Equal(UniqueSinglesPlugin.RepositoryOwner, plugin.Owner);
         Assert.Equal(UniqueSinglesPlugin.RepositoryUrl, plugin.GithubUrl);
         Assert.Equal("Lidarr.Plugin.UniqueSingles", assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void Assembly_ReferencesSupportedLidarrAssemblyVersions()
+    {
+        var assembly = typeof(UniqueSinglesScanCommand).Assembly;
+        var references = assembly.GetReferencedAssemblies()
+            .Where(reference => reference.Name is "Lidarr.Core" or "Lidarr.Common")
+            .ToDictionary(reference => reference.Name!, reference => reference.Version);
+
+        Assert.Equal(SupportedLidarrVersion, references["Lidarr.Core"]);
+        Assert.Equal(SupportedLidarrVersion, references["Lidarr.Common"]);
+        Assert.DoesNotContain(references.Values, version => version?.Major == 10);
     }
 }

--- a/tests/UniqueSingles.Test/UniqueSingles.Test.csproj
+++ b/tests/UniqueSingles.Test/UniqueSingles.Test.csproj
@@ -27,6 +27,7 @@
     <Compile Include="UniqueSinglesNotificationTests.cs" />
     <Compile Include="ScheduledTaskServiceTests.cs" />
     <Compile Include="UniqueSinglesScanTaskTests.cs" />
+    <Compile Include="AssemblySmokeTests.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1.

## Problem
The vendored `ext/Lidarr` submodule ships `<AssemblyVersion>10.0.0.*</AssemblyVersion>`, which the build stamps as `10.0.0.24098`. Lidarr's plugin loader strict-matches the referenced `Lidarr.Core` / `Lidarr.Common` version, so the plugin fails to load against a real Lidarr install and knocks Lidarr into plugin-less fallback mode (taking other plugins down with it).

## Fix
Add a CI step that rewrites `<AssemblyVersion>` to the target Lidarr release version (`3.1.3.4968`) before build. This mirrors Lidarr's own `build.sh` (line 22), which stamps its release assemblies with the product version the same way, so the reference now matches what a real Lidarr 3.1.3.4968 install actually loads.

A smoke test asserts the built assembly references the supported version and never a `10.x` version.

## Scope
Version fix only. This is a de-scoped alternative to #2 — the scheduled-scan hardening and the Tier-1 unmonitor behaviour change from that PR are intentionally excluded and should land separately so the crash fix can ship on its own.

## Notes
- The pin locks the plugin to the targeted Lidarr build (the loader strict-matches the version). Bump `LIDARR_VERSION` when retargeting a newer Lidarr release.
- `Assembly_ReferencesSupportedLidarrAssemblyVersions` only passes once the CI pin step has run (the committed submodule still carries `*`), so it is a CI-verified assertion, not a local one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)